### PR TITLE
Bug/exam period

### DIFF
--- a/julia_front/src/lib/utils/examPeriod.js
+++ b/julia_front/src/lib/utils/examPeriod.js
@@ -47,7 +47,11 @@ export async function loadExamPeriods(fetchWithAuth, API_ENDPOINTS) {
 export function filterExamPeriodsForDate(examPeriods, targetDate) {
 	if (!examPeriods || !targetDate) return [];
 	
-	const targetDateStr = targetDate.toISOString().split('T')[0]; // YYYY-MM-DD 형식
+	// UTC 변환 대신 로컬 날짜 사용 (타임존 차이로 인한 하루 차이 방지)
+	const year = targetDate.getFullYear();
+	const month = String(targetDate.getMonth() + 1).padStart(2, '0');
+	const day = String(targetDate.getDate()).padStart(2, '0');
+	const targetDateStr = `${year}-${month}-${day}`; // YYYY-MM-DD 형식
 	
 	return examPeriods.filter((ep) => {
 		// 시험 기간의 시작일과 종료일을 YYYY-MM-DD 형식으로 비교
@@ -63,6 +67,11 @@ export function filterExamPeriodsForDate(examPeriods, targetDate) {
 export function isEnglishExam(examPeriod, targetDate) {
 	if (!examPeriod.english_date || !targetDate) return false;
 	
-	const targetDateStr = targetDate.toISOString().split('T')[0];
+	// UTC 변환 대신 로컬 날짜 사용 (타임존 차이로 인한 하루 차이 방지)
+	const year = targetDate.getFullYear();
+	const month = String(targetDate.getMonth() + 1).padStart(2, '0');
+	const day = String(targetDate.getDate()).padStart(2, '0');
+	const targetDateStr = `${year}-${month}-${day}`;
+	
 	return targetDateStr === examPeriod.english_date;
 }


### PR DESCRIPTION
## 문제
- 시험 기간이 캘린더에서 하루씩 늦게 출력되는 문제 발생
- 기존에 toISOString()을 사용하여 UTC 기준으로 날짜를 문자열로 변환하는 로직을 사용
- 한국 시간(KST, UTC+9)에서 UTC로 변환 시 하루 전날로 변경되는 타임존 차이 문제
## 해결방안
- UTC 변환 대신 로컬 날짜를 직접 사용하여 문자열로 변환하는 로직으로 변경
- filterExamPeriodsForDate와 isEnglishExam 함수 모두 수정
## 수정된 함수
- `filterExamPeriodsForDate`: 시험 기간 날짜 필터링
- `isEnglishExam`: 영어 시험 날짜 확인

Closes #25